### PR TITLE
NEW 1.1 (tk12362) Extend functionality to orders: …

### DIFF
--- a/core/modules/modchangeinvoicethirdparty.class.php
+++ b/core/modules/modchangeinvoicethirdparty.class.php
@@ -59,7 +59,7 @@ class modchangeinvoicethirdparty extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Description of module changeinvoicethirdparty";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '1.0';
+		$this->version = '1.1';
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)
@@ -91,7 +91,9 @@ class modchangeinvoicethirdparty extends DolibarrModules
 		//							'dir' => array('output' => 'othermodulename'),      // To force the default directories names
 		//							'workflow' => array('WORKFLOW_MODULE1_YOURACTIONTYPE_MODULE2'=>array('enabled'=>'! empty($conf->module1->enabled) && ! empty($conf->module2->enabled)', 'picto'=>'yourpicto@changeinvoicethirdparty')) // Set here all workflow context managed by module
 		//                        );
-				$this->module_parts = array('hooks' => array('invoicecard') );
+				$this->module_parts = array(
+					'hooks' => array('invoicecard', 'ordercard')
+				);
 
 		// Data directories to create when module is enabled.
 		// Example: this->dirs = array("/changeinvoicethirdparty/temp");


### PR DESCRIPTION
# NEW 
Enable users to change the third party of an order.

## Context
Up to Dolibarr 5.0, it was possible (using hidden options) to change the third party of an order or invoice. Since then, the feature has been removed as it would sometimes put the database in an inconsistent state.

However, there are a few use cases for such a feature, to be used with the utmost caution, hence this module was created (initially intended for invoices only – this PR extends the functionality to orders too).

# Branch management
When (if) this PR is merged into `master`, a new "release" branch called `1.1` should be created from it.