### PR TITLE
NEW: extend feature to shipments

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,0 +1,12 @@
+# Change Log
+
+## Version 2.0
+ - NEW Permet aussi de changer le tiers d'une expédition.
+ - Renomme le module dans l'interface
+
+## Version 1.1
+ - NEW Permet aussi de changer le tiers d'une commande
+   (depuis Dolibarr 5.0, ce n'est plus possible en standard)
+
+## Version 1.0
+ - FIX Permet de changer le tiers d'une facture

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Module ChangeInvoiceThirdParty
+
+Ce module permet de modifier le tiers d’une commande, facture ou expédition en brouillon.
+
+Il faut avoir le droit idoine (*Modification d'un client sur une facture, 
+une commande ou une livraison*) pour pouvoir voir le bouton *Lier vers un
+autre tiers*.
+
+## Notes d’implémentation
+Le module utilise exclusivement les hooks :
+* addMoreActionsButtons (pour afficher un bouton sur les fiches en brouillon si le
+  droit est défini)
+* formConfirm (pour afficher un dialogue quand on clique sur le bouton)
+* doActions (pour changer le tiers lorsqu'on confirme l'action)

--- a/core/modules/modchangeinvoicethirdparty.class.php
+++ b/core/modules/modchangeinvoicethirdparty.class.php
@@ -59,7 +59,7 @@ class modchangeinvoicethirdparty extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Description of module changeinvoicethirdparty";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '1.1';
+		$this->version = '2.0';
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)
@@ -92,7 +92,7 @@ class modchangeinvoicethirdparty extends DolibarrModules
 		//							'workflow' => array('WORKFLOW_MODULE1_YOURACTIONTYPE_MODULE2'=>array('enabled'=>'! empty($conf->module1->enabled) && ! empty($conf->module2->enabled)', 'picto'=>'yourpicto@changeinvoicethirdparty')) // Set here all workflow context managed by module
 		//                        );
 				$this->module_parts = array(
-					'hooks' => array('invoicecard', 'ordercard')
+					'hooks' => array('invoicecard', 'ordercard', 'expeditioncard')
 				);
 
 		// Data directories to create when module is enabled.
@@ -180,7 +180,7 @@ class modchangeinvoicethirdparty extends DolibarrModules
 		// Add here list of permission defined by an id, a label, a boolean and two constant strings.
 		// Example:
 		$this->rights[$r][0] = $this->numero . $r;	// Permission id (must not be already used)
-		$this->rights[$r][1] = 'Change invoice thidparty';	// Permission label
+		$this->rights[$r][1] = 'Change thidparty';	// Permission label
 		$this->rights[$r][3] = 0; 					// Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'updatethirdparty';				// In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
 		//$this->rights[$r][5] = 'updatethirdparty';				// In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)

--- a/langs/en_US/changeinvoicethirdparty.lang
+++ b/langs/en_US/changeinvoicethirdparty.lang
@@ -1,8 +1,10 @@
-Module104871Name = Change Invoice Thirdparty
-Module104871Desc = Allow to change invoice thirdparty
-Permission1048710 = Allow to change invoice thirdparty
+Module104871Name = Change third party
+Module104871Desc = Enables you to change the third party of an order, an invoice or a shipment
+Permission1048710 = Change third party of orders, invoices or shipments
 
-ATMAbout = This module has been developed by <a href="http://www.atm-consulting.fr" target="_blank">ATM Consulting</a><br>You can find the documentation on our <a href="http://wiki.atm-consulting.fr/index.php/Accueil" target="_blank">wiki</a><br><br>For any question or feedback, contact us on <a href="mailto:support@atm-consulting.fr">support@atm-consulting.fr</a><br><br>For any commercial question, contact us on <a href="mailto:contact@atm-consulting.fr">contact@atm-consulting.fr</a> or at +33 9 77 19 50 70<br><br>Find our other modules on <a href="http://www.dolistore.com/search.php?orderby=position&orderway=desc&search_query=atm&submit_search=Rechercher" target="_blank">Dolistore</a>
+ATMAbout = This module was developed by <a href="http://www.atm-consulting.fr" target="_blank">ATM Consulting</a><br>You can find documentation on our <a href="http://wiki.atm-consulting.fr/index.php/Accueil" target="_blank">wiki</a><br><br>For any question or feedback, please contact us at <a href="mailto:support@atm-consulting.fr">support@atm-consulting.fr</a><br><br>For any business inquiry, please contact us at <a href="mailto:contact@atm-consulting.fr">contact@atm-consulting.fr</a> or at +33 9 77 19 50 70<br><br>Find our other modules on <a href="http://www.dolistore.com/search.php?orderby=position&orderway=desc&search_query=atm&submit_search=Rechercher" target="_blank">Dolistore</a>
 
-changeinvoicethirdpartySetup = Change Invoice Thirdparty module setup
-changeinvoicethirdpartyAbout = About Change Invoice Thirdparty
+changeinvoicethirdpartySetup = Change third party module setup
+changeinvoicethirdpartyAbout = About Change third party
+
+changeinvoicethirdparty=Change third party

--- a/langs/fr_FR/changeinvoicethirdparty.lang
+++ b/langs/fr_FR/changeinvoicethirdparty.lang
@@ -1,10 +1,10 @@
-Module104871Name = Modification client facture
-Module104871Desc = Modification client facture Description
-Permission1048710 = Modification d'un client sur une facture
+Module104871Name = Modification client
+Module104871Desc = Module permettant de modifier le tiers d’une facture, une commande ou une livraison
+Permission1048710 = Modification d'un client sur une facture, une commande ou une livraison
 
 ATMAbout = Ce module a été développé par <a href="http://www.atm-consulting.fr" target="_blank">ATM Consulting</a><br>Vous pouvez retrouver la documentation sur notre <a href="http://wiki.atm-consulting.fr/index.php/Accueil" target="_blank">wiki</a><br><br>Pour toute question technique ou retour, contactez-nous sur <a href="mailto:support@atm-consulting.fr">support@atm-consulting.fr</a><br><br>Pour toute question commerciale, contactez-nous sur <a href="mailto:contact@atm-consulting.fr">contact@atm-consulting.fr</a> ou au +33 9 77 19 50 70<br><br>Retrouvez nos autres modules sur <a href="http://www.dolistore.com/search.php?orderby=position&orderway=desc&search_query=atm&submit_search=Rechercher" target="_blank">Dolistore</a>
 
-changeinvoicethirdpartySetup = Configuration du module Modification client facture
-changeinvoicethirdpartyAbout = A propos du module Modification client facture
+changeinvoicethirdpartySetup = Configuration du module Modification client
+changeinvoicethirdpartyAbout = A propos du module Modification client
 
-changeinvoicethirdparty=Modification client facture
+changeinvoicethirdparty=Modification client


### PR DESCRIPTION
# CLOSED
New PR: https://github.com/ATM-Consulting/dolibarr_module_changeinvoicethirdparty/pull/3

# New Version 2.0
 - NEW Permet aussi de changer le tiers d'une expédition.
 - Renomme le module dans l'interface
 - Je l'ai appelée 2.0 parce qu'initialement, j'avais introduit une rupture de compatibilité avec PHP 5.5 et inférieurs, mais je suis revenu dessus pour garder la compatibilité ; cependant, comme c'est une nouvelle fonctionnalité, ça se discute
 - Ça résout aussi un souci (avant, il fallait recharger la page pour voir le bon tiers ; j'ai mis un `$object->fetchthirdparty()` directement dans le hook pour qu'il n'y ait plus besoin de recharger).